### PR TITLE
Add ingress

### DIFF
--- a/examples/nyctaxi/README.md
+++ b/examples/nyctaxi/README.md
@@ -5,8 +5,12 @@ This tutorial walks through running the included nyc taxi example.
 # Set up environment
 
 - Create a minikube cluster
+- Install ingress controller (https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/#enable-the-ingress-controller)
+- Run `kubectl proxy` so that Kubernetes API is accessible on localhost:8001
 
 # Download data
+
+Download the CSV files and store in `/mnt/ssd/nyc_taxis/csv` for now since this is hard-coded in a few places.
 
 ```bash
 ./bin/download-yellow-2018.sh

--- a/examples/nyctaxi/templates/executor.yaml
+++ b/examples/nyctaxi/templates/executor.yaml
@@ -35,3 +35,20 @@ spec:
   selector:
     ballista-name: {{ .name }}
   type: ClusterIP
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+  name: {{ .name }}
+  namespace: default
+spec:
+  rules:
+    - host: {{ .name }}.info
+      http:
+        paths:
+          - backend:
+              serviceName: {{ .name }}
+              servicePort: grpc


### PR DESCRIPTION
This PR adds ingress so that query plans can be sent directly to executor nodes from outside the cluster, as a step towards being able to run examples in "client mode" (using Apache Spark terminology).