### PR TITLE
Use Alpine Linux for server image; add tini

### DIFF
--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -3,7 +3,12 @@ ARG REPO=andygrove
 FROM $REPO/ballista-platform as build
 
 # Copy the statically-linked binary into a scratch container.
-FROM scratch
+FROM alpine:3.10
+
+# Install Tini for better signal handling
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
 COPY --from=build /tmp/ballista/target/x86_64-unknown-linux-musl/release/ballista-server /
 USER 1000
 


### PR DESCRIPTION
[tini][] provides better signal handling for free, so containers should
stop quickly upon termination. Using alpine also means we can get
a shell in the pods for debugging!

[tini]: https://github.com/krallin/tini